### PR TITLE
Very simple fix for animation flickering issue when returning to selected view controller from history.

### DIFF
--- a/SAHistoryNavigationViewController/SAHistoryNavigationViewController.swift
+++ b/SAHistoryNavigationViewController/SAHistoryNavigationViewController.swift
@@ -219,7 +219,7 @@ extension SAHistoryNavigationViewController: SAHistoryViewControllerDelegate {
                 self.coverView.hidden = true
                 self.historyContentView.hidden = true
                 self.historyViewController.view.alpha = 0.0
-                self.setNavigationBarHidden(false, animated: true)
+                self.setNavigationBarHidden(false, animated: false)
             }
         }
     }


### PR DESCRIPTION
Before when selecting a view controller from the history, the navigation bar would be animating in at the same time, doing it without animation solves this problem and the transition is much nicer looking.

Cheers! This is a great idea!
