### PR TITLE
[#38] fixed crash when changing navbar delegate

### DIFF
--- a/SAHistoryNavigationViewController/SAHistoryNavigationViewController.swift
+++ b/SAHistoryNavigationViewController/SAHistoryNavigationViewController.swift
@@ -101,8 +101,6 @@ public class SAHistoryNavigationViewController: UINavigationController {
         }
         gestureRecognizer.delegate = self
         navigationBar.addGestureRecognizer(gestureRecognizer)
-        
-        navigationBar.delegate = self
     }
     
     override func willSetHistoryDelegate(delegate: SAHistoryNavigationViewControllerDelegate?) {


### PR DESCRIPTION
According to Apple documentation:

> If the navigation bar was created by a navigation controller and is being managed by that object, you must not change the value of this property. Navigation controllers act as the delegate for any navigation bars they create.

Since this is exactly what's happening here, the OS triggers a trap and any controller subclassing SAHistoryNavigationViewController will crash as well.

Simply removing the delegate assignment solves this issue.
