### PR TITLE
Added support for landscape orientation

### DIFF
--- a/SAHistoryNavigationViewController/SAHistoryViewAnimatedTransitioning.swift
+++ b/SAHistoryNavigationViewController/SAHistoryViewAnimatedTransitioning.swift
@@ -36,14 +36,14 @@ class SAHistoryViewAnimatedTransitioning: NSObject, UIViewControllerAnimatedTran
         else { return }
         let containerView = transitionContext.containerView
         if isPresenting {
-            pushAniamtion(transitionContext, containerView: containerView, toVC: toVC, fromVC: fromVC)
+            pushAnimation(transitionContext, containerView: containerView, toVC: toVC, fromVC: fromVC)
             return
         }
-        popAniamtion(transitionContext, containerView: containerView, toVC: toVC, fromVC: fromVC)
+        popAnimation(transitionContext, containerView: containerView, toVC: toVC, fromVC: fromVC)
     }
 
     //MARK: - Animations
-    fileprivate func pushAniamtion(_ transitionContext: UIViewControllerContextTransitioning, containerView: UIView, toVC: UIViewController, fromVC: UIViewController) {
+    fileprivate func pushAnimation(_ transitionContext: UIViewControllerContextTransitioning, containerView: UIView, toVC: UIViewController, fromVC: UIViewController) {
         guard let hvc = toVC as? SAHistoryViewController else { return }
         
         containerView.addSubview(toVC.view)
@@ -67,11 +67,12 @@ class SAHistoryViewAnimatedTransitioning: NSObject, UIViewControllerAnimatedTran
         }
     }
     
-    fileprivate func popAniamtion(_ transitionContext: UIViewControllerContextTransitioning, containerView: UIView, toVC: UIViewController, fromVC: UIViewController) {
+    fileprivate func popAnimation(_ transitionContext: UIViewControllerContextTransitioning, containerView: UIView, toVC: UIViewController, fromVC: UIViewController) {
         guard let hvc = fromVC as? SAHistoryViewController else { return }
         
         containerView.addSubview(toVC.view)
         toVC.view.isHidden = true
+        toVC.view.frame = containerView.bounds
         hvc.view.frame = containerView.bounds
         hvc.collectionView.transform = CGAffineTransform(scaleX: Const.scale, y: Const.scale)
         

--- a/SAHistoryNavigationViewControllerSample/SAHistoryNavigationViewControllerSample/Info.plist
+++ b/SAHistoryNavigationViewControllerSample/SAHistoryNavigationViewControllerSample/Info.plist
@@ -32,6 +32,8 @@
 	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
 		<string>UIInterfaceOrientationPortrait</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>


### PR DESCRIPTION
Added support for mixing landscape and portrait orientations when navigating through a UINaivigationController. This feature is especially useful for tablets, where supporting just one orientation is not practical.

In regards to supporting both portrait and landscape, there is one aspect worth discussing: when restoring a landscape screenshot into a portrait screen or viceversa, how should the animation look? Stretching the photo to fill the new size did not look right to me, so I left the old behavior, which zooms the image until it hits one of the screen's edges, then, it is replaced by destination VC with the proper bounds.